### PR TITLE
optimize(core): org-roam-node-read, linear->constant time filter-fn

### DIFF
--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -441,8 +441,10 @@ SORT-FN is a function to sort nodes. See `org-roam-node-read-sort-by-file-mtime'
 for an example sort function.
 If REQUIRE-MATCH, the minibuffer prompt will require a match."
   (let* ((nodes (org-roam-node-read--completions))
-         (nodes (cl-remove-if-not (lambda (n)
-                                    (if filter-fn (funcall filter-fn (cdr n)) t)) nodes))
+         (nodes (if filter-fn
+                    (cl-remove-if-not
+                     (lambda (n) (funcall filter-fn (cdr n)) t))
+                  nodes))
          (sort-fn (or sort-fn
                       (when org-roam-node-default-sort
                         (intern (concat "org-roam-node-read-sort-by-"


### PR DESCRIPTION
In org-roam-node-read, there is no need to check filter-fn for each node, move the branch up, O(n) to O(1)

###### Motivation for this change

found this while debugging, easy optimisation